### PR TITLE
Fix compile error for simon.ino

### DIFF
--- a/simon.ino
+++ b/simon.ino
@@ -67,7 +67,7 @@ void play(int pressed) //' play{
     drawscreen(0);
 } //' }play
 
-static int get_note() //' getnote{
+int get_note() //' getnote{
 {
   byte pressed = 0;
   while (pressed == 0) {
@@ -83,7 +83,7 @@ static int get_note() //' getnote{
   return pressed;
 } //' }getnote
 
-static int random_note()
+int random_note()
 {
   return 1 + GD.random(4);
 }


### PR DESCRIPTION
In Arduino 1.6.6, I get compile errors for the “static” declaration on
these functions:

In file included from
/var/folders/k9/f_tsmrws4tx4ds4qz9v2t_q80000gn/T/arduino_8bf5aa90b7758e6
58fa974d60cf28371/simon.ino:3:0:
/Users/combs/Dropbox/Arduino/libraries/Gameduino2/GD2.h:418:36:
warning: '**progmem**' attribute ignored [-Wattributes]
void copy(const PROGMEM uint8_t *src, int count);
^
/var/folders/k9/f_tsmrws4tx4ds4qz9v2t_q80000gn/T/arduino_8bf5aa90b7758e6
58fa974d60cf28371/simon.ino: In function 'int get_note()':
simon:69: error: 'int get_note()' was declared 'extern' and later
'static' [-fpermissive]
static int get_note()
^
simon:8: error: previous declaration of 'int get_note()' [-fpermissive]
}
^
/var/folders/k9/f_tsmrws4tx4ds4qz9v2t_q80000gn/T/arduino_8bf5aa90b7758e6
58fa974d60cf28371/simon.ino: In function 'int random_note()':
simon:82: error: 'int random_note()' was declared 'extern' and later
'static' [-fpermissive]
static int random_note()
^
simon:9: error: previous declaration of 'int random_note()'
[-fpermissive]

^
In file included from
/var/folders/k9/f_tsmrws4tx4ds4qz9v2t_q80000gn/T/arduino_8bf5aa90b7758e6
58fa974d60cf28371/simon.ino:1:0:
/Users/combs/Dropbox/Arduino IDE/Arduino
1.6.6.app/Contents/Java/hardware/arduino/avr/libraries/EEPROM/EEPROM.h:
At global scope:
/Users/combs/Dropbox/Arduino IDE/Arduino
1.6.6.app/Contents/Java/hardware/arduino/avr/libraries/EEPROM/EEPROM.h:1
45:20: warning: 'EEPROM' defined but not used [-Wunused-variable]
static EEPROMClass EEPROM;
^
exit status 1
'int get_note()' was declared 'extern' and later 'static' [-fpermissive]

Removing the “static” declaration causes it to compile and work. 

Thanks,
Chris
