### PR TITLE
STM32L4 & BlackIce Support

### DIFF
--- a/GD2.h
+++ b/GD2.h
@@ -82,6 +82,14 @@ static class ASPI_t ASPI;
 
 #endif
 
+#if defined(ARDUINO_STM32L4_BLACKICE)
+// BlackIce Board uses SPI1 on the Arduino header.
+#define SPI SPI1
+// Board Support:
+//   JSON: http://www.hamnavoe.com/package_millerresearch_mystorm_index.json
+//   Source: https://github.com/millerresearch/arduino-mystorm
+#endif
+
 #if SDCARD
 
 #if defined(VERBOSE) && (VERBOSE > 0)
@@ -204,7 +212,7 @@ class sdcard {
     pin = p;
 
     pinMode(pin, OUTPUT);
-#if !defined(__DUE__) && !defined(TEENSYDUINO)
+#if !defined(__DUE__) && !defined(TEENSYDUINO) && !defined(ARDUINO_ARCH_STM32L4)
     SPI.setClockDivider(SPI_CLOCK_DIV64);
 #endif
     desel();
@@ -280,7 +288,7 @@ class sdcard {
     for (;;);
 #endif
 
-#if !defined(__DUE__) && !defined(ESP8266)
+#if !defined(__DUE__) && !defined(ESP8266) && !defined(ARDUINO_ARCH_STM32L4)
     SPI.setClockDivider(SPI_CLOCK_DIV2);
     SPSR = (1 << SPI2X);
 #endif
@@ -1383,7 +1391,7 @@ public:
  * compiler. So redefine PROGMEM to nothing.
  */
 
-#if defined(ESP8266)
+#if defined(ESP8266) || defined(ARDUINO_ARCH_STM32L4)
 #undef PROGMEM
 #define PROGMEM
 #endif

--- a/transports/wiring.h
+++ b/transports/wiring.h
@@ -26,7 +26,7 @@ public:
     ios();
 
     SPI.begin();
-#ifdef TEENSYDUINO
+#if defined(TEENSYDUINO) || defined(ARDUINO_ARCH_STM32L4)
     SPI.beginTransaction(SPISettings(3000000, MSBFIRST, SPI_MODE0));
 #else
 #if !defined(__DUE__) && !defined(ESP8266)
@@ -221,7 +221,7 @@ public:
       *dst++ = SPI.transfer(0);
     stream();
   }
-#if defined(ARDUINO) && !defined(__DUE__) && !defined(ESP8266)
+#if defined(ARDUINO) && !defined(__DUE__) && !defined(ESP8266) && !defined(ARDUINO_ARCH_STM32L4)
   void wr_n(uint32_t addr, byte *src, uint16_t n)
   {
     __end(); // stop streaming


### PR DESCRIPTION
Add exceptions to support the [arduino-STM32L4](https://github.com/GrumpyOldPizza/arduino-STM32L4) core by @GrumpyOldPizza.

Tested on an STM32L433CC running on the [BlackIce board](https://forum.mystorm.uk/) using the arduino-mystorm board support package.

- Additional info and setup on the forum:
  https://forum.mystorm.uk/t/arduino-board-package-for-blackice/279
- Github source:
  https://github.com/millerresearch/arduino-mystorm
- Note: Had to switch the SPI bus to SPI1 for the BlackIce board.

I'm looking forward to incorporating the iCE40 FPGA into a game. Maybe a swapforth j1a coprocessor? I'm still learning Forth and Verilog so that may take me some time.

Pictures of the Gameduino3 running on the BlackIce board:

![img_20171227_160717](https://user-images.githubusercontent.com/37681/34396521-0a63a5ba-eb21-11e7-8166-1be37c6a9f81.jpg)
![img_20171227_160922](https://user-images.githubusercontent.com/37681/34396536-35315cec-eb21-11e7-89ec-bd0b7aedb809.jpg)

Thanks for your time and for making Gameduino3!