### PR TITLE
Use an instance of SPI that can be more easily customized

### DIFF
--- a/GD2.h
+++ b/GD2.h
@@ -13,7 +13,6 @@
 #include "wiring.h"
 #endif
 
-#include "SPI.h"
 #include "Arduino.h"
 #include <stdarg.h>
 

--- a/GD2.h
+++ b/GD2.h
@@ -13,6 +13,7 @@
 #include "wiring.h"
 #endif
 
+#include "SPI.h"
 #include "Arduino.h"
 #include <stdarg.h>
 


### PR DESCRIPTION
The ESP32 has multiple SPI busses, which can be configured during instantiation of the Arduino SPI API as per the [Arduino SPI example](https://github.com/espressif/arduino-esp32/blob/master/libraries/SPI/examples/SPI_Multiple_Buses/SPI_Multiple_Buses.ino).

This pull request changes all calls to `SPI.method()` to instead use a globally-instantiated instance like `spi->method()`. This allows one to more easily change what SPI bus is used.