### PR TITLE
TEXTVGA/8X8 Terminal Example

### DIFF
--- a/GD2Terminal.cpp
+++ b/GD2Terminal.cpp
@@ -1,0 +1,317 @@
+#include "GD2Terminal.h"
+
+// 160 character line buffer
+char terminal_linebuffer[] = "                                                                                                                                                                 ";
+
+uint8_t *const linebuffer_const = (uint8_t*)terminal_linebuffer;
+
+GD2Terminal::GD2Terminal() {
+  scrollback_length = 100;
+  foreground_color = 15;
+  background_color = 0;
+  disable_vga_background_colors();
+  draw_x_coord = 0;
+  draw_y_coord = 0;
+  terminal_window_bg_color = 0;
+  terminal_window_opacity = 200;
+  reset();
+}
+
+void GD2Terminal::begin(uint8_t initial_font_mode) {
+  if (initial_font_mode == TEXTVGA) {
+    set_font_vga();
+  }
+  else {
+    set_font_8x8();
+  }
+  set_size_fullscreen();
+}
+
+void GD2Terminal::set_size_fullscreen() {
+  int character_width = 8;
+  int character_height = 8;
+  if (current_font == TEXTVGA) {
+    character_height = 16;
+  }
+  int row_count = floor(GD.h / character_height);
+  int col_count = floor(GD.w / character_width);
+  change_size(row_count, col_count);
+}
+
+
+void GD2Terminal::set_window_bg_color(uint32_t color) {
+  terminal_window_bg_color = color;
+}
+
+void GD2Terminal::set_window_opacity(uint8_t opacity) {
+  terminal_window_opacity = opacity;
+}
+
+void GD2Terminal::enable_vga_background_colors() {
+  background_colors_enabled = true;
+}
+
+void GD2Terminal::disable_vga_background_colors() {
+  background_colors_enabled = false;
+}
+
+uint32_t GD2Terminal::bitmap_byte_size() {
+  return scrollback_length * bytes_per_line;
+}
+
+uint32_t GD2Terminal::ram_end_address() {
+  return bitmap_byte_size()+2;
+}
+
+void GD2Terminal::change_size(uint16_t rows, uint16_t columns){
+  lines_per_screen = rows;
+  characters_per_line = columns;
+  bytes_per_line = characters_per_line;
+  if (current_font == TEXTVGA)
+    bytes_per_line *= 2;
+
+  draw_width = characters_per_line * 8;
+  draw_height = lines_per_screen * line_pixel_height;
+
+  // Create a 1x1 white pixel bitmap handle for drawing shaded rectangles
+  GD.cmd_memset(bitmap_byte_size(), 0xFF, 2); // Two bytes for 1 RGB565 pixel
+  GD.BitmapHandle(TERMINAL_BITMAP_HANDLE_BACKGROUND);
+  GD.BitmapSource(bitmap_byte_size());
+  GD.BitmapLayout(RGB565, 2, 1);
+  GD.BitmapSize(NEAREST, REPEAT, REPEAT,
+                characters_per_line * 8,
+                lines_per_screen * line_pixel_height);
+  reset();
+}
+
+void GD2Terminal::set_font_8x8() {
+  current_font = TEXT8X8;
+  line_pixel_height = 8;
+}
+
+void GD2Terminal::set_font_vga() {
+  current_font = TEXTVGA;
+  line_pixel_height = 16;
+}
+
+void GD2Terminal::reset() {
+  bell = 0;
+  line_count = 1;
+  cursor_index = 0;
+  last_line_address = 0;
+
+  erase_line_buffer();
+  set_scrollbar_handle_size();
+}
+
+void GD2Terminal::ring_bell() {
+  // Bell animation for 60 frames.
+  bell = 60;
+}
+
+void GD2Terminal::update_scrollbar_position(uint16_t new_position) {
+  scrollbar_position = new_position;
+  if (scrollbar_position < scrollbar_size_half)
+    scrollbar_position = scrollbar_size_half;
+  if (scrollbar_position > 65535 - scrollbar_size_half)
+    scrollbar_position = 65535 - scrollbar_size_half;
+  scrollbar_position_percent = ((float)scrollbar_position - (float)scrollbar_size_half) / (65535.0 - (float)scrollbar_size);
+  scrollbar_position_percent *= 100;
+  scrollbar_position_percent = floor(scrollbar_position_percent);
+  scrollbar_position_percent /= 100;
+  scrollbar_position_percent = 1.0 - scrollbar_position_percent;
+  if (line_count <= lines_per_screen) {
+    scroll_offset = 0;
+  }
+  else {
+    scroll_offset = (uint16_t) (scrollbar_position_percent * ((float)line_count - lines_per_screen));
+  }
+}
+
+void GD2Terminal::update_scrollbar() {
+  switch (GD.inputs.track_tag & 0xff) {
+  case TAG_SCROLLBAR:
+    update_scrollbar_position(GD.inputs.track_val);
+    break;
+  }
+}
+
+void GD2Terminal::upload_to_graphics_ram() {
+  GD.cmd_memwrite(last_line_address*bytes_per_line, bytes_per_line);
+  GD.copy(linebuffer_const, bytes_per_line);
+}
+
+void GD2Terminal::set_scrollbar_handle_size() {
+  lines_per_screen_percent = ((float) lines_per_screen) / ((float) line_count);
+  if (lines_per_screen_percent > 1.0)
+    lines_per_screen_percent = 1.0;
+  scrollbar_size = (uint16_t) floor(lines_per_screen_percent * 65535.0);
+  scrollbar_size_half = (uint16_t) floor(lines_per_screen_percent * 0.5 * 65535.0);
+  update_scrollbar_position(65535);
+}
+
+void GD2Terminal::erase_line_buffer() {
+  // erase current line
+  for (uint8_t i=0; i<120; i++) {
+    terminal_linebuffer[i] = ' ';
+  }
+
+  // Set TEXTVGA default colors
+  if (current_font == TEXTVGA) {
+    for (uint8_t i=1; i<120; i+=2) {
+      terminal_linebuffer[i] = (background_color << 4) | foreground_color;
+    }
+  }
+}
+
+void GD2Terminal::new_line() {
+  // copy terminal_linebuffer to FT810 RAM
+  upload_to_graphics_ram();
+  cursor_index = 0;
+  line_count++;
+  if (line_count >= scrollback_length)
+    line_count = scrollback_length;
+  last_line_address++;
+  if (last_line_address > scrollback_length)
+    last_line_address = 0;
+
+  erase_line_buffer();
+  set_scrollbar_handle_size();
+}
+
+void GD2Terminal::append_string(const char* str) {
+  for(uint16_t i=0; i<strlen(str); i++) {
+    append_character(str[i]);
+  }
+  // for(char& c : str) {
+  //   // append_character(c);
+  // }
+  // append_character((char) 13);
+}
+
+void GD2Terminal::put_char(char newchar) {
+  if (current_font == TEXTVGA) {
+    terminal_linebuffer[cursor_index*2+1] = (background_color << 4) | foreground_color;
+    terminal_linebuffer[cursor_index*2] = newchar;
+  }
+  else {
+    terminal_linebuffer[cursor_index] = newchar;
+  }
+}
+
+uint8_t GD2Terminal::append_character(char newchar) {
+  if (cursor_index >= characters_per_line
+      || newchar == TERMINAL_KEY_CR
+      || newchar == TERMINAL_KEY_LF) {
+    new_line();
+    return LINE_FULL;
+  }
+
+  switch (newchar) {
+  case TERMINAL_KEY_BACKSPACE:
+    // delete current char if not at the beginning of the line
+    if (cursor_index > 0) {
+      put_char(' ');
+      cursor_index--;
+
+    }
+    break;
+  default:
+    put_char(newchar);
+    cursor_index++;
+    break;
+  }
+  return CHAR_READ;
+}
+
+void GD2Terminal::set_position(int x, int y) {
+  draw_x_coord = x;
+  draw_y_coord = y;
+}
+
+void GD2Terminal::draw() {
+  draw(draw_x_coord, draw_y_coord);
+}
+
+void GD2Terminal::draw(int startx, int starty) {
+  // Upload any lingering data from append_character calls.
+  upload_to_graphics_ram();
+
+  if (startx != draw_x_coord || starty != draw_y_coord) {
+    draw_x_coord = startx;
+    draw_y_coord = starty;
+  }
+
+  GD.SaveContext();
+
+  // Use bitmap handle 14 for text bitmaps
+  GD.BitmapHandle(TERMINAL_BITMAP_HANDLE_TEXT);
+  GD.BitmapSize(NEAREST, BORDER, BORDER, 480, line_pixel_height);
+  GD.BitmapLayout(current_font, bytes_per_line, 1);
+
+  uint16_t current_line_address = last_line_address;
+  if (scroll_offset > 0)
+    current_line_address = (current_line_address + (scrollback_length-scroll_offset)) % scrollback_length;
+
+  int16_t ycoord;
+  uint16_t min_lines = line_count;
+  if (line_count > lines_per_screen)
+    min_lines = lines_per_screen;
+
+  uint16_t max_xoffset = 0;
+  if (bell > 10) {
+    max_xoffset = bell / 10;
+    bell--;
+  }
+
+  GD.Begin(BITMAPS);
+
+  // Draw Background
+
+  if (current_font == TEXTVGA && background_colors_enabled)
+    // Use VGA background colors if enabled
+    GD.BlendFunc(ONE, ZERO);
+  else {
+    // Draw a shaded Terminal Background with a 1x1 stretched bitmap
+    GD.BlendFunc(SRC_ALPHA, ONE_MINUS_SRC_ALPHA);
+    GD.ColorRGB(terminal_window_bg_color);
+    GD.ColorA(terminal_window_opacity);
+    GD.Vertex2ii(draw_x_coord, draw_y_coord, TERMINAL_BITMAP_HANDLE_BACKGROUND);
+    GD.ColorA(255);
+  }
+
+  GD.ColorRGB(COLOR_WHITE);
+  // Draw Terminal Text
+  for (int i=0; i<min_lines; i++) {
+    ycoord = (draw_y_coord + (lines_per_screen * line_pixel_height)) - line_pixel_height - (line_pixel_height * i);
+    // Change the bitmap start address
+    GD.BitmapSource( current_line_address * bytes_per_line );
+    GD.Vertex2ii(max_xoffset ? GD.random(max_xoffset) + draw_x_coord : draw_x_coord,
+                 ycoord,
+                 TERMINAL_BITMAP_HANDLE_TEXT);
+    current_line_address = (current_line_address + (scrollback_length-1)) % scrollback_length;
+  }
+
+  // Draw Scrollbar
+  GD.BlendFunc(SRC_ALPHA, ONE_MINUS_SRC_ALPHA);
+  GD.ColorA(terminal_window_opacity);
+  GD.cmd_bgcolor(COLOR_VALHALLA);
+  GD.cmd_fgcolor(COLOR_LIGHT_STEEL_BLUE);
+
+  GD.Tag(TAG_SCROLLBAR);
+  GD.cmd_scrollbar(draw_x_coord + draw_width - SCROLLBAR_WIDTH,
+                   draw_y_coord + SCROLLBAR_HALF_WIDTH,
+                   SCROLLBAR_WIDTH,
+                   draw_height - SCROLLBAR_WIDTH,
+                   OPT_FLAT,
+                   scrollbar_position - scrollbar_size_half,
+                   scrollbar_size,
+                   65535);
+  GD.cmd_track(draw_x_coord + draw_width - SCROLLBAR_WIDTH,
+               draw_y_coord + SCROLLBAR_HALF_WIDTH,
+               SCROLLBAR_WIDTH,
+               draw_height - SCROLLBAR_WIDTH,
+               TAG_SCROLLBAR);
+
+  GD.RestoreContext();
+}

--- a/GD2Terminal.h
+++ b/GD2Terminal.h
@@ -1,0 +1,142 @@
+#ifndef __TERMINAL_H__
+#define __TERMINAL_H__
+
+#include <Arduino.h>
+#include <SPI.h>
+#include <GD2.h>
+
+// DB32 Pallete
+// https://github.com/geoffb/dawnbringer-palettes
+
+#define COLOR_BLACK            0x000000  // #000000
+#define COLOR_VALHALLA         0x222034  // #222034
+#define COLOR_LOULOU           0x45283c  // #45283c
+#define COLOR_OILED_CEDAR      0x663931  // #663931
+#define COLOR_ROPE             0x8f563b  // #8f563b
+#define COLOR_TAHITI_GOLD      0xdf7126  // #df7126
+#define COLOR_TWINE            0xd9a066  // #d9a066
+#define COLOR_PANCHO           0xeec39a  // #eec39a
+
+#define COLOR_GOLDEN_FIZZ      0xfbf236  // #fbf236
+#define COLOR_ATLANTIS         0x99e550  // #99e550
+#define COLOR_RAINFOREST       0x6abe30  // #6abe30
+#define COLOR_ELF_GREEN        0x37946e  // #37946e
+#define COLOR_DELL             0x4b692f  // #4b692f
+#define COLOR_VERDIGRIS        0x524b24  // #524b24
+#define COLOR_OPAL             0x323c39  // #323c39
+#define COLOR_DEEP_KOAMARU     0x3f3f74  // #3f3f74
+
+#define COLOR_VENICE_BLUE      0x306082  // #306082
+#define COLOR_ROYAL_BLUE       0x5b6ee1  // #5b6ee1
+#define COLOR_CORNFLOWER       0x639bff  // #639bff
+#define COLOR_VIKING           0x5fcde4  // #5fcde4
+#define COLOR_LIGHT_STEEL_BLUE 0xcbdbfc  // #cbdbfc
+#define COLOR_WHITE            0xffffff  // #ffffff
+#define COLOR_HEATHER          0x9badb7  // #9badb7
+#define COLOR_TOPAZ            0x847e87  // #847e87
+
+#define COLOR_DIM_GRAY         0x696a6a  // #696a6a
+#define COLOR_SMOKEY_ASH       0x595652  // #595652
+#define COLOR_CLAIRVOYANT      0x76428a  // #76428a
+#define COLOR_RED              0xac3232  // #ac3232
+#define COLOR_MANDY            0xd95763  // #d95763
+#define COLOR_PLUM             0xd77bba  // #d77bba
+#define COLOR_STINGER          0x8f974a  // #8f974a
+#define COLOR_BROWN            0x8a6f30  // #8a6f30
+
+#define TERMINAL_KEY_BELL 7
+#define TERMINAL_KEY_BACKSPACE 8
+#define TERMINAL_KEY_CR 13
+#define TERMINAL_KEY_LF 10
+#define TERMINAL_KEY_SPACE 32
+#define TERMINAL_KEY_ESC 27
+#define TERMINAL_KEY_DEL 127
+
+#define SCROLLBAR_WIDTH 20
+#define SCROLLBAR_HALF_WIDTH 10
+
+#define TAG_SCROLLBAR 201
+
+#define LINE_FULL 0
+#define CHAR_READ 1
+
+#define TERMINAL_VGA_BLACK   0
+#define TERMINAL_VGA_BLUE    1
+#define TERMINAL_VGA_GREEN   2
+#define TERMINAL_VGA_CYAN    3
+#define TERMINAL_VGA_RED     4
+#define TERMINAL_VGA_MAGENTA 5
+#define TERMINAL_VGA_YELLOW  6
+#define TERMINAL_VGA_WHITE   7
+#define TERMINAL_VGA_BRIGHT_BLACK   8
+#define TERMINAL_VGA_BRIGHT_BLUE    9
+#define TERMINAL_VGA_BRIGHT_GREEN   10
+#define TERMINAL_VGA_BRIGHT_CYAN    11
+#define TERMINAL_VGA_BRIGHT_RED     12
+#define TERMINAL_VGA_BRIGHT_MAGENTA 13
+#define TERMINAL_VGA_BRIGHT_YELLOW  14
+#define TERMINAL_VGA_BRIGHT_WHITE   15
+
+#define TERMINAL_BITMAP_HANDLE_TEXT 14
+#define TERMINAL_BITMAP_HANDLE_BACKGROUND 13
+
+class GD2Terminal {
+public:
+  GD2Terminal();
+
+  uint16_t cursor_index;
+  uint16_t line_count;
+  uint16_t last_line_address;
+  uint16_t lines_per_screen;
+  uint8_t line_pixel_height;
+  uint8_t characters_per_line;
+  uint8_t bytes_per_line;
+  uint8_t current_font;
+  bool background_colors_enabled;
+  uint8_t foreground_color;
+  uint8_t background_color;
+  uint16_t scrollback_length;
+  float lines_per_screen_percent;
+  uint16_t scrollbar_size;
+  uint16_t scrollbar_size_half;
+  uint16_t scrollbar_position;
+  float scrollbar_position_percent;
+  uint16_t scroll_offset;
+  int draw_x_coord;
+  int draw_y_coord;
+  uint16_t draw_width;
+  uint16_t draw_height;
+  uint32_t terminal_window_bg_color;
+  uint8_t terminal_window_opacity;
+
+  uint16_t bell;
+
+  void begin(uint8_t initial_font_mode);
+  void reset();
+  void set_font_8x8();
+  void set_font_vga();
+  uint32_t bitmap_byte_size();
+  uint32_t ram_end_address();
+  void change_size(uint16_t rows, uint16_t columns);
+  void enable_vga_background_colors();
+  void disable_vga_background_colors();
+  void ring_bell();
+  uint8_t append_character(char newchar);
+  void append_string(const char* str);
+  void new_line();
+  void upload_to_graphics_ram();
+  void update_scrollbar_position(uint16_t new_position);
+  void update_scrollbar();
+  void set_window_bg_color(uint32_t color);
+  void set_window_opacity(uint8_t opacity);
+  void draw();
+  void draw(int startx, int starty);
+  void set_position(int x, int y);
+  void set_size_fullscreen();
+ private:
+  void erase_line_buffer();
+  void put_char(char newchar);
+  void set_scrollbar_handle_size();
+};
+
+#endif

--- a/examples/terminal.ino
+++ b/examples/terminal.ino
@@ -1,0 +1,199 @@
+#include <SPI.h>
+#include <GD2.h>
+#include <GD2Terminal.h>
+#include <math.h>
+
+GD2Terminal terminal;
+
+// Standard GD3 Chip Select Pins
+#define GD3_CS 8
+#define GD3_SDCS 9
+
+// Some nice colors to work with
+const uint32_t colors_endesga32[] = {
+  0xbe4a2f,
+  0xd77643,
+  0xead4aa,
+  0xe4a672,
+  0xb86f50,
+  0x733e39,
+  0x3e2731,
+  0xa22633,
+  0xe43b44,
+  0xf77622,
+  0xfeae34,
+  0xfee761,
+  0x63c74d,
+  0x3e8948,
+  0x265c42,
+  0x193c3e,
+  0x124e89,
+  0x0099db,
+  0x2ce8f5,
+  0xffffff,
+  0xc0cbdc,
+  0x8b9bb4,
+  0x5a6988,
+  0x3a4466,
+  0x262b44,
+  0x181425,
+  0xff0044,
+  0x68386c,
+  0xb55088,
+  0xf6757a,
+  0xe8b796,
+  0xc28569,
+};
+
+void setup() {
+  // Serial.begin(115200);
+  // while (!Serial) {}
+
+  SPI.begin();
+
+  // Gameduino3 Setup
+  // Serial.println("GD.begin()");
+  GD.begin(GD_CALIBRATE | GD_TRIM | GD_STORAGE, GD3_CS, GD3_SDCS);
+  // Serial.println("GD.begin() Complete");
+
+  // Setup the terminal. Must come after GD.begin -------------------
+  terminal.begin(TEXTVGA);
+  // terminal.begin(TEXT8X8);
+  terminal.set_window_bg_color(0x000000);  // Background window color
+  terminal.set_window_opacity(200);  // 0-255
+
+  // Changing Fonts -------------------------------------------------
+  // 8X8 Monochrome
+  // terminal.set_font_8x8();
+  // VGA 16-color
+  terminal.set_font_vga();
+  // VGA background colors are disabled by default.
+  terminal.disable_vga_background_colors();
+  // Enable character backgound color. Disables window color&opacity
+  // terminal.enable_vga_background_colors();
+
+  // Font changes must be followed by setting a size ---------------
+  // Fullscreen
+  terminal.set_size_fullscreen();
+  // Custom Size
+  // terminal.change_size(row_count, column_count);
+
+  // Get FT81X first available ram address (after terminal data) ---
+  // terminal.ram_end_address();
+
+  GD.ClearColorRGB(0x000000);
+}
+
+
+#define TWO_PI 6.283185307179586476925286766559
+float start_offset = 0;
+
+void draw_circles() {
+  GD.SaveContext();
+  GD.Clear();
+
+  // Draw some moving circles
+  GD.PointSize(16 * 30); // means 30 pixels
+  GD.Begin(POINTS);
+  int start_x = floor(GD.w / 34);
+  int start_y = floor(GD.h / 2);
+  start_offset += TWO_PI/1024;
+  if (start_offset > TWO_PI) {
+    start_offset = 0;
+  }
+  int x;
+  for (int i = 0; i < 32; i++) {
+    GD.ColorRGB(colors_endesga32[i]);
+    x = (i + 2) * start_x;
+    GD.Vertex2ii(x, start_y + ((GD.h/3) * sin(x + start_offset)));
+  }
+  GD.RestoreContext();
+}
+
+// FPS and time per game loop
+uint32_t delta_time_start = 0;
+uint32_t delta_time_micros = 30000; // initial guess
+// Display List size
+uint16_t display_list_offset = 0;
+char line_buffer[160];
+uint32_t last_terminal_refresh = 0;
+
+void loop() {
+  // Frame time start
+  delta_time_start = micros();
+
+  // Get touchscreen inputs
+  GD.get_inputs();
+  terminal.update_scrollbar();
+
+  // Your app update code here
+
+  // Your app draw code here
+  draw_circles();
+
+  // Every 2 seconds print something
+  if (millis() > last_terminal_refresh + 2000) {
+    terminal.append_character('\n');
+
+    // Print time
+    terminal.foreground_color = TERMINAL_VGA_BRIGHT_MAGENTA;
+    terminal.background_color = TERMINAL_VGA_BRIGHT_CYAN;
+    terminal.append_string("[Time] ");
+
+    terminal.foreground_color = TERMINAL_VGA_WHITE;
+    terminal.background_color = TERMINAL_VGA_BLACK;
+    sprintf(line_buffer, "%02d:%02d:%02d ", 16, 41, GD.random(60));
+    terminal.append_string(line_buffer);
+
+    terminal.foreground_color = TERMINAL_VGA_BRIGHT_WHITE;
+    sprintf(line_buffer, "%04d-%02d-%02d\n", 2021, 2, 14);
+    terminal.append_string(line_buffer);
+
+    terminal.foreground_color = TERMINAL_VGA_BRIGHT_GREEN;
+    sprintf(line_buffer, "[Battery] %1.2f V\n", 2.5+2*((float)GD.random(1024)/1024.0));
+    terminal.append_string(line_buffer);
+
+    terminal.foreground_color = TERMINAL_VGA_BRIGHT_CYAN;
+    terminal.append_string("\nAll Characters:");
+
+    // Print all characters
+    char c;
+    for (int i=0; i<256; i++) {
+      terminal.foreground_color = i%16;
+      c = i;
+      if (c > 255 || c == '\n' || c == '\r')
+        c = ' ';
+      terminal.append_character(c);
+      if (i%terminal.characters_per_line == 0)
+        terminal.append_character('\n');
+    }
+    terminal.append_character('\n');
+
+    last_terminal_refresh = millis();
+  } // end last_terminal_refresh check
+
+  // Draw terminal.
+  terminal.draw(0, 0);
+
+  // Print extra debug info;
+  // FPS and Display List Usage for the previous frame.
+  float delta_time = (float)delta_time_micros * 1e-6;
+  sprintf(line_buffer,
+          "FPS: %.2f --- DisplayList: %3.2f%% (%u / 8192)",
+          1.0 / delta_time,
+          100.0 * ((float) display_list_offset/8192),
+          display_list_offset);
+  // Draw white text with a black outline.
+  GD.ColorRGB(COLOR_LIGHT_STEEL_BLUE);
+  GD.cmd_text(1, GD.h-16,   18, 0, line_buffer);
+
+  // Get the size (current position) of the display list.
+  GD.finish();
+  display_list_offset = GD.rd16(REG_CMD_DL);
+
+  GD.swap();
+
+  // Frame time end.
+  delta_time_micros = micros() - delta_time_start;
+}
+


### PR DESCRIPTION
Added the GD2Terminal class and a terminal.ino example. GD2Terminal draws a
terminal with a scroll bar using the TEXTVGA or TEXT8X8 bitmap formats. ASCII
characters 0-255 can be rendered.

Resources used:
- Bitmap handles: 13, 14
- Tag for scrollbar: 201

VRAM Usage:
- 480x272: 6KB for TEXT8X8, 12KB for TEXTVGA
- 800x480: 10KB for TEXT8X8, 20KB for TEXTVGA
- 1280x720: 16KB for TEXT8X8, 32KB for TEXTVGA
Formula: scroll history (100 lines) * characters per line *
  (1 byte for TEXT8X8 or 2 bytes for TEXTVGA)